### PR TITLE
feat: Add home-manager module

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,6 @@
-{pkgs, ...}: pkgs.callPackage ./package.nix {}
+{
+  pkgs,
+  additionalPaths ? [],
+  ...
+}:
+pkgs.callPackage ./package.nix {inherit additionalPaths;}

--- a/flake.nix
+++ b/flake.nix
@@ -32,5 +32,7 @@
       overlays.default = _final: prev: {
         claude-code = outputs.packages.${prev.system}.default;
       };
+
+      homeManagerModules.default = import ./home-module.nix outputs;
     };
 }

--- a/home-module.nix
+++ b/home-module.nix
@@ -1,0 +1,33 @@
+outputs: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.claude-code;
+  package = outputs.packages.${pkgs.stdenv.hostPlatform.system}.default;
+in {
+  options.programs.claude-code = {
+    enableLocalBinSymlink = lib.mkOption {
+      type = lib.types.bool;
+      default = pkgs.stdenv.isLinux;
+      description = ''
+        Whether to create a symlink at ~/.local/bin/claude.
+        Enabled by default on Linux to avoid "claude command not found" warnings.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.claude-code.package = lib.mkDefault (
+      if cfg.enableLocalBinSymlink
+      then (package.override {additionalPaths = ["${config.home.homeDirectory}/.local/bin"];})
+      else package
+    );
+
+    # Create symlink to ~/.local/bin/claude (enabled by default on Linux)
+    home.file.".local/bin/claude" = lib.mkIf cfg.enableLocalBinSymlink {
+      source = "${cfg.package}/bin/claude";
+    };
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -7,6 +7,7 @@
   zlib,
   writableTmpDirAsHomeHook,
   versionCheckHook,
+  additionalPaths ? [],
 }: let
   sourcesData = lib.importJSON ./sources.json;
   inherit (sourcesData) version;
@@ -15,6 +16,10 @@
   source =
     sources.${stdenv.hostPlatform.system}
     or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  additionalOptions =
+    lib.optionalString (additionalPaths != [])
+    "--prefix PATH : ${builtins.concatStringsSep ":" additionalPaths}";
 in
   stdenv.mkDerivation rec {
     pname = "claude";
@@ -43,7 +48,7 @@ in
 
     # Wrap the binary with environment variables to disable telemetry and auto-updates
     postFixup = ''
-      wrapProgram $out/bin/claude \
+      wrapProgram $out/bin/claude ${additionalOptions} \
         --set DISABLE_AUTOUPDATER 1 \
         --set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
         --set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \


### PR DESCRIPTION
## Summary
  - Add home-manager module that extends the official [`programs.claude-code`](https://searchix.ovh/options/home-manager/search?query=claude-code) options
  - Automatically create symlink at `~/.local/bin/claude` on Linux to resolve "claude command not found"
  warnings
  - Add `additionalPaths` parameter to package for PATH configuration

  ## Changes
  - `home-module.nix`: New home-manager module with `enableLocalBinSymlink` option
  - `package.nix`: Add `additionalPaths` parameter for `--prefix PATH` configuration
  - `flake.nix`: Export `homeManagerModules.default`
  - `README.md`: Add documentation for home-manager module usage

  ## Usage
  ```nix
  modules = [
    inputs.claude-code-overlay.homeManagerModules.default
    {
      programs.claude-code.enable = true;
    }
  ];
```

Closes #2

Tested on [my local NixOS environment](https://github.com/turtton/dotnix/commit/f758c2145b092926f59a2e7ee534530aebaa04a6).
During testing, I discovered that the symlink at `~/.local/bin/claude` doesn't necessarily need to point to the
  actual Claude binary - Claude Code only checks for the existence of a file at that path.
