### PR TITLE
refactor(flake): migrate from flake-utils to flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,20 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -34,25 +34,25 @@
         "type": "github"
       }
     },
-    "root": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/home-module.nix
+++ b/home-module.nix
@@ -1,11 +1,11 @@
-outputs: {
+self: {
   config,
   lib,
   pkgs,
   ...
 }: let
   cfg = config.programs.claude-code;
-  package = outputs.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  package = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
 in {
   options.programs.claude-code = {
     enableLocalBinSymlink = lib.mkOption {


### PR DESCRIPTION
## Summary

Migrate from `flake-utils` to `flake-parts` for flake output generation.

## What Changed

- Replace `flake-utils.lib.eachSystem` with `flake-parts.lib.mkFlake`
- Use `perSystem` for system-specific package definitions
- Move `overlays` and `homeManagerModules` to `flake` attribute
- Update `home-module.nix` to accept `self` instead of `outputs`
- Update `flake.lock` with new `flake-parts` dependency

## Why

`flake-parts` provides a more modular and composable approach using the NixOS module system, enabling better organisation of flake outputs and improved code reuse through its `perSystem` and `flake` attribute patterns.

## Testing

- `nix flake check` passes
- `nix flake show` confirms all outputs are preserved
- Dry-run build succeeds