### PR TITLE
fix: replace versionCheckHook with custom strings-based version check

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -57,8 +57,10 @@ in
 
     doInstallCheck = true;
 
-    # Custom version check using strings command instead of running the binary
-    # This avoids the "TypeError: failed to initialize Segmenter" error in Nix sandbox
+    # Workaround: Custom version check using strings command instead of running the binary
+    # The standard versionCheckHook fails with "TypeError: failed to initialize Segmenter" in Nix sandbox.
+    # This workaround extracts version string from the binary without executing it.
+    # Note: This is not a documented nixpkgs pattern, but a practical workaround for this specific issue.
     # See: https://github.com/ryoppippi/claude-code-overlay/issues/5
     installCheckPhase = let
       inherit (lib) pipe escapeRegex escapeShellArg;


### PR DESCRIPTION
## Summary

- Replace `versionCheckHook` with a custom `installCheckPhase` that uses `strings` command
- Avoids executing the binary during version check, which fails in Nix sandbox with "TypeError: failed to initialize Segmenter" error
- Verifies version by searching for the version string in the binary using `strings` and `grep`

Fixes #5

## Note

This is a **workaround**, not a documented nixpkgs pattern. The `strings` command approach is a practical solution to avoid executing the binary in the Nix sandbox environment. No official nixpkgs documentation recommends this method, but it effectively solves the issue where the standard `versionCheckHook` fails due to the bun runtime's Segmenter initialization error.

## Test plan

- [x] Run `nix build` to verify the package builds successfully
- [x] Verify the installCheckPhase passes by checking for the version string in the binary