### PR TITLE
chore(dev): use mkShellNoCC for lighter dev shell

### DIFF
--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -61,7 +61,7 @@
 
           formatter = treefmtEval.config.build.wrapper;
 
-          devShells.default = pkgs.mkShell {
+          devShells.default = pkgs.mkShellNoCC {
             inherit (self'.checks.git-hooks-check) shellHook;
           };
         };


### PR DESCRIPTION
Switch from `mkShell` to `mkShellNoCC` since no C compiler is needed.

The dev shell only runs git-hooks (nixfmt, deadnix, statix) which don't require native compilation. This reduces unnecessary dependencies and makes the shell lighter.