### PR TITLE
feat: bundle gh CLI with claude-code package

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,23 @@ in
 
 ## Available Packages
 
-When using the overlay, the package is available as `pkgs.claude-code`.
+The overlay provides two package variants:
+
+| Package | Description |
+| ------- | ----------- |
+| `pkgs.claude-code` | Default package with GitHub CLI (`gh`) bundled. Recommended for most users as Claude Code frequently uses `gh` for GitHub operations. |
+| `pkgs.claude-code-minimal` | Minimal package without bundled tools. Use this if you want to provide your own `gh` version or don't need GitHub integration. |
+
+### Using claude-code-minimal with custom tools
+
+If you want to use your own version of `gh` or add other tools to the PATH, use `claude-code-minimal` with `additionalPaths`:
+
+```nix
+# In your configuration
+pkgs.claude-code-minimal.override {
+  additionalPaths = [ "${pkgs.gh}/bin" "${pkgs.git}/bin" ];
+}
+```
 
 ## How It Works
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         "x86_64-darwin"
         "aarch64-darwin"
       ];
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+      forAllSystems = nixpkgs.lib.genAttrs systems;
     in
     {
       packages = forAllSystems (
@@ -33,13 +33,17 @@
           };
         in
         {
-          claude = pkgs.callPackage ./default.nix { };
+          claude = pkgs.callPackage ./default.nix {
+            additionalPaths = [ "${pkgs.gh}/bin" ];
+          };
+          claude-minimal = pkgs.callPackage ./default.nix { };
           default = self.packages.${system}.claude;
         }
       );
 
       overlays.default = _final: prev: {
-        claude-code = self.packages.${prev.system}.default;
+        claude-code = self.packages.${prev.system}.claude;
+        claude-code-minimal = self.packages.${prev.system}.claude-minimal;
       };
     };
 }


### PR DESCRIPTION
## Summary
- Bundle GitHub CLI (`gh`) with the default `claude-code` package
- Add `claude-code-minimal` variant for users who want custom tool setups
- Update README with package documentation

## Why
Claude Code frequently uses `gh` for GitHub operations (creating PRs, viewing issues, etc.). Bundling it by default improves the out-of-box experience.

## Changes
- `pkgs.claude-code` - now includes `gh` in PATH
- `pkgs.claude-code-minimal` - without bundled tools, for custom setups