### PR TITLE
feat: wrap Linux packages in buildFHSEnv for agent-teams compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,21 @@ nix run github:ryoppippi/nix-claude-code#latest
 nix run github:ryoppippi/nix-claude-code#stable
 ```
 
+### FHS-Wrapped Variants (Linux only)
+
+Claude Code's `agent-teams` feature downloads an additional Linux binary at runtime to `~/.local/share/claude`. That binary is unpatched and expects the standard FHS dynamic linker at `/lib64/ld-linux-x86-64.so.2`, which does not exist on NixOS. The flake exposes FHS-wrapped variants that provide a glibc-based root so these runtime-downloaded binaries can execute.
+
+| Attribute                                | Description                            |
+| ---------------------------------------- | -------------------------------------- |
+| `packages.${system}.claude-fhs`          | FHS-wrapped `claude` (latest)          |
+| `packages.${system}.claude-minimal-fhs`  | FHS-wrapped `claude-minimal` (latest)  |
+| `packages.${system}.stable-fhs`          | FHS-wrapped `stable`                   |
+| `packages.${system}.stable-minimal-fhs`  | FHS-wrapped `stable-minimal`           |
+| `pkgs.claude-code-fhs` (overlay)         | Overlay alias for `claude-fhs`         |
+| `pkgs.claude-code-minimal-fhs` (overlay) | Overlay alias for `claude-minimal-fhs` |
+
+The default `claude` / `claude-code` packages are unchanged — the FHS variants are opt-in because `buildFHSEnv` relies on user namespaces (`bwrap`), which are unavailable in some environments (e.g. some CI runners, restricted containers).
+
 ### Telemetry
 
 By default, this package does **not** disable telemetry or nonessential network traffic. This is intentional — disabling them breaks features like remote-control that depend on these subsystems.

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,8 @@
 
           mkClaudeMinimal = sourcesFile: pkgs.callPackage ./package.nix { inherit sourcesFile; };
 
+          mkClaudeFhs = claudePackage: pkgs.callPackage ./package-fhs.nix { claude-code = claudePackage; };
+
           versionedPackages = builtins.listToAttrs (
             builtins.map (version: {
               name = version;
@@ -55,18 +57,30 @@
           );
 
           latestSourcesFile = ./versions/${latestVersion + ".json"};
+
+          fhsPackages = nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            claude-fhs = mkClaudeFhs (mkClaude latestSourcesFile);
+            claude-minimal-fhs = mkClaudeFhs (mkClaudeMinimal latestSourcesFile);
+          };
         in
         {
           claude = mkClaude latestSourcesFile;
           claude-minimal = mkClaudeMinimal latestSourcesFile;
           default = self.packages.${system}.claude;
         }
+        // fhsPackages
         // versionedPackages
       );
 
-      overlays.default = _final: prev: {
-        claude-code = self.packages.${prev.stdenv.hostPlatform.system}.claude;
-        claude-code-minimal = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal;
-      };
+      overlays.default =
+        _final: prev:
+        {
+          claude-code = self.packages.${prev.stdenv.hostPlatform.system}.claude;
+          claude-code-minimal = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal;
+        }
+        // nixpkgs.lib.optionalAttrs prev.stdenv.isLinux {
+          claude-code-fhs = self.packages.${prev.stdenv.hostPlatform.system}.claude-fhs;
+          claude-code-minimal-fhs = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal-fhs;
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,8 @@
           fhsPackages = nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
             claude-fhs = mkClaudeFhs (mkClaude latestSourcesFile);
             claude-minimal-fhs = mkClaudeFhs (mkClaudeMinimal latestSourcesFile);
+            stable-fhs = mkClaudeFhs (mkClaude stableSourcesFile);
+            stable-minimal-fhs = mkClaudeFhs (mkClaudeMinimal stableSourcesFile);
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,8 @@
 
           mkClaudeMinimal = sourcesFile: pkgs.callPackage ./package.nix { inherit sourcesFile; };
 
+          mkClaudeFhs = claudePackage: pkgs.callPackage ./package-fhs.nix { claude-code = claudePackage; };
+
           versionedPackages = builtins.listToAttrs (
             builtins.map (version: {
               name = version;
@@ -61,6 +63,11 @@
 
           latestSourcesFile = ./versions/${latestVersion + ".json"};
           stableSourcesFile = ./versions/${stableVersion + ".json"};
+
+          fhsPackages = nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            claude-fhs = mkClaudeFhs (mkClaude latestSourcesFile);
+            claude-minimal-fhs = mkClaudeFhs (mkClaudeMinimal latestSourcesFile);
+          };
         in
         {
           claude = mkClaude latestSourcesFile;
@@ -70,12 +77,19 @@
           stable-minimal = mkClaudeMinimal stableSourcesFile;
           default = self.packages.${system}.claude;
         }
+        // fhsPackages
         // versionedPackages
       );
 
-      overlays.default = _final: prev: {
-        claude-code = self.packages.${prev.stdenv.hostPlatform.system}.claude;
-        claude-code-minimal = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal;
-      };
+      overlays.default =
+        _final: prev:
+        {
+          claude-code = self.packages.${prev.stdenv.hostPlatform.system}.claude;
+          claude-code-minimal = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal;
+        }
+        // nixpkgs.lib.optionalAttrs prev.stdenv.isLinux {
+          claude-code-fhs = self.packages.${prev.stdenv.hostPlatform.system}.claude-fhs;
+          claude-code-minimal-fhs = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal-fhs;
+        };
     };
 }

--- a/package-fhs.nix
+++ b/package-fhs.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  buildFHSEnv,
+  claude-code,
+}:
+# Wrap claude-code in an FHS-compatible environment so that binaries
+# downloaded at runtime (e.g. by the agent-teams feature) can find
+# the standard dynamic linker at /lib64/ld-linux-x86-64.so.2.
+# See: https://github.com/ryoppippi/claude-code-overlay/issues/16
+buildFHSEnv {
+  name = "claude";
+  inherit (claude-code) meta;
+
+  targetPkgs = pkgs: [
+    claude-code
+    pkgs.stdenv.cc.cc.lib
+    pkgs.zlib
+  ];
+
+  runScript = lib.getExe claude-code;
+}

--- a/package-fhs.nix
+++ b/package-fhs.nix
@@ -11,6 +11,9 @@ buildFHSEnv {
   name = "claude";
   inherit (claude-code) meta;
 
+  # `stdenv.cc.cc.lib` and `zlib` are also in claude-code's buildInputs, but
+  # they must be present in the FHS root so that *runtime-downloaded* binaries
+  # (which are not autoPatchelf'd) can resolve them via the standard loader.
   targetPkgs = pkgs: [
     claude-code
     pkgs.stdenv.cc.cc.lib


### PR DESCRIPTION
## Summary

- Adds `claude-fhs` and `claude-minimal-fhs` packages (Linux only) that wrap the existing claude packages in `buildFHSEnv` so runtime-downloaded binaries (e.g. from agent-teams) can find `/lib64/ld-linux-x86-64.so.2`
- Exposes matching overlay attrs `claude-code-fhs` and `claude-code-minimal-fhs` on Linux
- The existing `claude` / `claude-minimal` packages and `claude-code` / `claude-code-minimal` overlay attrs are unchanged — the FHS variants are opt-in
- macOS is a no-op (no new attrs)

## How it works

A new `package-fhs.nix` wraps a given claude package in `buildFHSEnv`. In `flake.nix`, an `mkClaudeFhs` helper applies this on Linux to produce the `*-fhs` variants, which are added to both `packages` and `overlays.default` via `lib.optionalAttrs pkgs.stdenv.isLinux`.

## Context

On NixOS, the agent-teams feature downloads an unpatched Linux binary to `~/.local/share/claude` which fails due to the missing FHS dynamic linker at `/lib64/ld-linux-x86-64.so.2`. Running claude via the FHS-wrapped variant provides this linker, allowing runtime-downloaded binaries to execute.

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in FHS-wrapped package variants for Linux: claude-fhs, claude-minimal-fhs, stable-fhs, and stable-minimal-fhs.
  * These variants enable better compatibility for runtime-downloaded Linux binaries that require an FHS/glibc environment.
  * Default packages remain unchanged; FHS variants are Linux-only and opt-in.

* **Documentation**
  * README updated with guidance and names for the new FHS-wrapped variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/nix-claude-code/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->