### PR TITLE
ci: run gitleaks and formatting through nix flake check

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,19 +6,7 @@ on:
       - main
 
 jobs:
-  gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/setup-nix
-        with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Run Gitleaks
-        run: nix run nixpkgs#gitleaks -- detect --source . --config .gitleaks.toml
-
-  fmt-check:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/README.md
+++ b/README.md
@@ -370,12 +370,12 @@ The flake provides two package variants (exposed via the overlay):
 
 In addition to per-version attributes, the flake exposes channel aliases that track Anthropic's release channels. The `latest` channel follows the newest release (cross-checked against both the npm registry and Anthropic's distribution server), while `stable` follows the slower-moving stable channel, which intentionally lags behind `latest`.
 
-| Attribute                            | Channel                                          |
-| ------------------------------------ | ------------------------------------------------ |
-| `packages.${system}.default`         | Latest release (same as `latest`)                |
-| `packages.${system}.latest`          | Latest release, with `gh` bundled                |
-| `packages.${system}.stable`          | Stable channel release, with `gh` bundled        |
-| `packages.${system}.stable-minimal`  | Stable channel release, without bundled tools    |
+| Attribute                           | Channel                                       |
+| ----------------------------------- | --------------------------------------------- |
+| `packages.${system}.default`        | Latest release (same as `latest`)             |
+| `packages.${system}.latest`         | Latest release, with `gh` bundled             |
+| `packages.${system}.stable`         | Stable channel release, with `gh` bundled     |
+| `packages.${system}.stable-minimal` | Stable channel release, without bundled tools |
 
 ```bash
 # Latest release

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -59,22 +59,37 @@
             };
           };
 
-          # Expose a full gitleaks scan as a flake check so `nix flake check`
-          # covers secret detection. The flake sandbox has no `.git`, so we scan
-          # the cleaned working tree with `--no-git` rather than the git history.
-          checks.gitleaks =
-            pkgs.runCommand "gitleaks"
-              {
-                nativeBuildInputs = [ pkgs.gitleaks ];
-              }
-              ''
-                gitleaks detect \
-                  --source ${pkgs.lib.cleanSource ./..} \
-                  --config ${gitleaksConfig} \
-                  --no-git \
-                  --redact
-                touch "$out"
-              '';
+          checks = {
+            # Expose a full gitleaks scan as a flake check so `nix flake check`
+            # covers secret detection. The flake sandbox has no `.git`, so we
+            # scan the cleaned working tree with `--no-git` rather than history.
+            gitleaks =
+              pkgs.runCommand "gitleaks"
+                {
+                  nativeBuildInputs = [ pkgs.gitleaks ];
+                }
+                ''
+                  gitleaks detect \
+                    --source ${pkgs.lib.cleanSource ./..} \
+                    --config ${gitleaksConfig} \
+                    --no-git \
+                    --redact
+                  touch "$out"
+                '';
+
+            # Validate the Renovate config in CI. The matching pre-commit hook
+            # only runs on `git commit`, so a dedicated check keeps the config
+            # covered by `nix flake check` once the pre-commit check is disabled.
+            renovate-config =
+              pkgs.runCommand "renovate-config"
+                {
+                  nativeBuildInputs = [ pkgs.renovate ];
+                }
+                ''
+                  renovate-config-validator --strict ${./../.github/renovate.json5}
+                  touch "$out"
+                '';
+          };
 
           pre-commit = {
             # These hooks run on `git commit` via the dev shell. `nix flake

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -37,9 +37,19 @@
           pkgs,
           ...
         }:
+        let
+          # Shared by the gitleaks flake check (full `detect`) and the
+          # commit-time pre-commit hook (`protect --staged`), so both stages
+          # honour the same rules.
+          gitleaksConfig = ./../.gitleaks.toml;
+        in
         {
           treefmt = {
-            projectRootFile = ".git/config";
+            # Format-check the whole repository, not just `dev/`, so the
+            # `treefmt` flake check covers every tracked file. `cleanSource`
+            # strips `.git`, so anchor the project root on `flake.nix`.
+            projectRoot = pkgs.lib.cleanSource ./..;
+            projectRootFile = "flake.nix";
             programs = {
               nixfmt.enable = true;
               deadnix.enable = true;
@@ -49,26 +59,50 @@
             };
           };
 
-          pre-commit.settings = {
-            src = ./..;
-            package = pkgs.prek;
-            hooks = {
-              treefmt = {
-                enable = true;
-                package = config.treefmt.build.wrapper;
-              };
-              renovate-config-validator = {
-                enable = true;
-                entry = "${pkgs.lib.getExe' pkgs.renovate "renovate-config-validator"}";
-                files = "renovate\\.json5?$";
-                language = "system";
-              };
-              gitleaks = {
-                enable = true;
-                name = "gitleaks";
-                entry = "${pkgs.lib.getExe pkgs.gitleaks} protect --staged --config ${./../.gitleaks.toml}";
-                language = "system";
-                pass_filenames = false;
+          # Expose a full gitleaks scan as a flake check so `nix flake check`
+          # covers secret detection. The flake sandbox has no `.git`, so we scan
+          # the cleaned working tree with `--no-git` rather than the git history.
+          checks.gitleaks =
+            pkgs.runCommand "gitleaks"
+              {
+                nativeBuildInputs = [ pkgs.gitleaks ];
+              }
+              ''
+                gitleaks detect \
+                  --source ${pkgs.lib.cleanSource ./..} \
+                  --config ${gitleaksConfig} \
+                  --no-git \
+                  --redact
+                touch "$out"
+              '';
+
+          pre-commit = {
+            # These hooks run on `git commit` via the dev shell. `nix flake
+            # check` covers the same ground through the dedicated `treefmt` and
+            # `gitleaks` checks, so disable the pre-commit flake check to avoid
+            # running gitleaks and treefmt twice.
+            check.enable = false;
+            settings = {
+              src = ./..;
+              package = pkgs.prek;
+              hooks = {
+                treefmt = {
+                  enable = true;
+                  package = config.treefmt.build.wrapper;
+                };
+                renovate-config-validator = {
+                  enable = true;
+                  entry = "${pkgs.lib.getExe' pkgs.renovate "renovate-config-validator"}";
+                  files = "renovate\\.json5?$";
+                  language = "system";
+                };
+                gitleaks = {
+                  enable = true;
+                  name = "gitleaks";
+                  entry = "${pkgs.lib.getExe pkgs.gitleaks} protect --staged --config ${gitleaksConfig}";
+                  language = "system";
+                  pass_filenames = false;
+                };
               };
             };
           };


### PR DESCRIPTION
## Summary

Make `nix flake check` the single entry point for both secret detection and repository-wide formatting, then simplify the CI workflow accordingly. Modelled on the [ccusage](https://github.com/ryoppippi/ccusage) nix setup.

## Changes

### `dev/flake.nix`
- **Add a dedicated `gitleaks` check** running a full `gitleaks detect`. The flake sandbox has no `.git`, so it scans the cleaned working tree with `--no-git` (and `--redact`) instead of the git history.
- **Widen the `treefmt` check to the whole repo** via `treefmt.projectRoot = cleanSource ./..` (it previously only covered `dev/`). Anchored on `flake.nix` since `cleanSource` strips `.git`.
- **Disable the pre-commit flake check** (`pre-commit.check.enable = false`). The hooks still run on `git commit` through the dev shell, but no longer duplicate the gitleaks/treefmt work inside `nix flake check`.

### `.github/workflows/check.yaml`
- Collapse the standalone `gitleaks` and `fmt-check` jobs into a single `check` job that runs `cd dev && nix flake check`. `build-and-test` is unchanged.

### `README.md`
- Reformatted by the now repository-wide treefmt check (markdown table realignment).

## Why no duplication

Previously gitleaks/treefmt would have run twice inside `nix flake check` (once via the `pre-commit` check, once via the dedicated checks). Disabling `pre-commit.check.enable` keeps the hooks as local git hooks only, so each tool runs exactly once in CI. `treefmt` can't host gitleaks (it's a formatter multiplexer, not a scanner), so gitleaks stays a dedicated check.

## Verification

`cd dev && nix flake check -L` passes locally:
- `gitleaks` → `no leaks found`
- `treefmt` → 210 files, 0 changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `nix flake check` the single entry point for secret scanning, repo-wide formatting, and Renovate config validation. CI now runs one `check` job and avoids duplicate work.

- **New Features**
  - Add a `gitleaks` flake check that scans the cleaned working tree with `--no-git` and `--redact`, using `./../.gitleaks.toml`.
  - Expand the `treefmt` flake check to cover the whole repo by anchoring on `flake.nix`.
  - Add a `renovate-config` flake check that runs `renovate-config-validator --strict` on `.github/renovate.json5`.

- **Refactors**
  - Disable `pre-commit.check.enable`; hooks still run on `git commit` via the dev shell.
  - Replace separate `gitleaks` and `fmt-check` CI jobs with a single `check` job running `cd dev && nix flake check`.

<sup>Written for commit de31c3a280004d1ce1122ca424e9a6dc29b92b92. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/nix-claude-code/pull/38?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

