### PR TITLE
fix(renovate): automerge nix lock updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,9 @@
 	lockFileMaintenance: {
 		enabled: true,
 		schedule: ['before 3am on Monday'],
+		automerge: true,
+		automergeType: 'pr',
+		automergeStrategy: 'squash',
 	},
 	nix: {
 		enabled: true,
@@ -33,9 +36,12 @@
 		// Group flake.lock updates
 		{
 			matchManagers: ['nix'],
-			matchFileNames: ['flake.lock'],
+			matchFileNames: ['flake.lock', 'dev/flake.lock'],
 			groupName: 'nix flake dependencies',
 			schedule: ['before 3am on Monday'],
+			automerge: true,
+			automergeType: 'pr',
+			automergeStrategy: 'squash',
 		},
 	],
 	prConcurrentLimit: 5,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,7 +38,7 @@
 			matchManagers: ['nix'],
 			matchFileNames: ['flake.lock', 'dev/flake.lock'],
 			groupName: 'nix flake dependencies',
-			schedule: ['before 3am on Monday'],
+			schedule: ['before 3am on Sunday'],
 			automerge: true,
 			automergeType: 'pr',
 			automergeStrategy: 'squash',


### PR DESCRIPTION
Summary:
- Enable PR automerge for Renovate lock file maintenance.
- Apply the same squash automerge behaviour to grouped Nix flake dependency updates.
- Include dev/flake.lock in the Nix lockfile rule so both lock files follow the same policy.

Why:
Renovate's current lock file maintenance PRs are created with automerge disabled by config, even after CI succeeds. This makes the lock maintenance PR stay open until it is merged manually.

Validation:
- nix shell nixpkgs#renovate -c renovate-config-validator .github/renovate.json5
- nix flake check -L (from dev/)
- nix build -L
- nix run . -- --version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automerging for PR-based dependency updates with a squash merge strategy.
  * Extended grouped package rules so grouped lockfile updates are eligible for the same automerge behavior.
  * Result: dependency-update PRs for configured groups will be merged automatically using the configured strategy, reducing follow-up actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/nix-claude-code/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->