### PR TITLE
feat: add poppler-utils to runtime PATH for PDF support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
           mkClaude =
             sourcesFile:
             pkgs.callPackage ./package.nix {
-              additionalPaths = [ "${pkgs.gh}/bin" ];
+              additionalPaths = [ "${pkgs.gh}/bin" "${pkgs.poppler-utils}/bin" ];
               inherit sourcesFile;
             };
 


### PR DESCRIPTION
## Summary

Claude Code's `Read` tool can render PDFs by converting pages to images via `pdftoppm` (from `poppler-utils`), but this fails at runtime when `pdftoppm` isn't on `PATH`:

```
pdftoppm is not installed. Install poppler-utils (e.g. `brew install poppler`
or `apt-get install poppler-utils`) to enable PDF page rendering.
```

This PR adds `poppler_utils` to `additionalPaths` alongside `gh`, so PDF reading works out of the box for the non-minimal package. The `claude-minimal` variant is left unchanged — users opting for minimal can provide it themselves via `additionalPaths` override.

## Changes

- `flake.nix`: add `"${pkgs.poppler_utils}/bin"` to the `additionalPaths` list in `mkClaude`

## AI Disclaimer
This PR was made entirely by Claude in response to it's PDF tool not working and me asking it to "fix it upstream"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `poppler-utils` to the runtime PATH via `additionalPaths` (alongside `gh`) so `pdftoppm` is available and PDF rendering in Claude Code’s `Read` tool works out of the box. Applies to the non-minimal package; `claude-minimal` remains unchanged.

<sup>Written for commit e75f567e45cfd6be3f2c148b61b728f23b939826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/nix-claude-code/pull/40?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated runtime environment so built packages include additional system utilities (notably the GitHub CLI and PDF utilities), ensuring those binaries are available at runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/nix-claude-code/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->