### PR TITLE
refactor(update.nu): add a main function and type every command signature

### DIFF
--- a/update.nu
+++ b/update.nu
@@ -117,80 +117,84 @@ def process-version [version: string] {
 	}
 }
 
-# Main execution
-let existing = (get-existing-versions)
-let existing_versions = $existing.versions
-let current_version = $existing.latest
+# Backfill every version file missing from the tracked range, refresh the
+# `stable` channel marker, and print the newest known version as the final line
+# for CI consumption.
+def main [] {
+	let existing = (get-existing-versions)
+	let existing_versions = $existing.versions
+	let current_version = $existing.latest
 
-let all_npm_versions = (http get $NPM_PACKAGE_URL | get versions | columns | semver-sort)
-let npm_latest = (http get $NPM_LATEST_URL | get version)
-# The stable channel intentionally lags behind the latest release.
-let gcs_latest = (fetch-gcs-channel "latest")
-let stable_version = (fetch-gcs-channel "stable")
+	let all_npm_versions = (http get $NPM_PACKAGE_URL | get versions | columns | semver-sort)
+	let npm_latest = (http get $NPM_LATEST_URL | get version)
+	# The stable channel intentionally lags behind the latest release.
+	let gcs_latest = (fetch-gcs-channel "latest")
+	let stable_version = (fetch-gcs-channel "stable")
 
-# Determine the newest version reported by either source.
-let latest_version = ([$npm_latest $gcs_latest] | semver-sort | last)
+	# Determine the newest version reported by either source.
+	let latest_version = ([$npm_latest $gcs_latest] | semver-sort | last)
 
-print $"Current version: ($current_version)"
-print $"npm latest:      ($npm_latest)"
-print $"GCS latest:      ($gcs_latest)"
-print $"GCS stable:      ($stable_version)"
-print $"Latest version:  ($latest_version)"
+	print $"Current version: ($current_version)"
+	print $"npm latest:      ($npm_latest)"
+	print $"GCS latest:      ($gcs_latest)"
+	print $"GCS stable:      ($stable_version)"
+	print $"Latest version:  ($latest_version)"
 
-# Find the earliest existing version to determine the backfill range.
-# Only backfill versions >= the earliest version we already track.
-let earliest = ($existing_versions | get 0?)
+	# Find the earliest existing version to determine the backfill range.
+	# Only backfill versions >= the earliest version we already track.
+	let earliest = ($existing_versions | get 0?)
 
-let missing_versions = (
-	$all_npm_versions
-	| where {|v| $v not-in $existing_versions and ($earliest == null or (semver-gte $v $earliest))}
-)
+	let missing_versions = (
+		$all_npm_versions
+		| where {|v| $v not-in $existing_versions and ($earliest == null or (semver-gte $v $earliest))}
+	)
 
-match ($missing_versions | is-empty) {
-	true => { print "All versions are up to date!" }
-	false => {
-		print $"Found ($missing_versions | length) missing version\(s\): ($missing_versions | str join ', ')"
+	match ($missing_versions | is-empty) {
+		true => { print "All versions are up to date!" }
+		false => {
+			print $"Found ($missing_versions | length) missing version\(s\): ($missing_versions | str join ', ')"
 
-		$missing_versions | each {|version|
-			print $"Processing ($version)..."
-			match (process-version $version) {
-				true => { print $"  Added ($version)" }
-				false => {}
-			}
-		} | ignore
+			$missing_versions | each {|version|
+				print $"Processing ($version)..."
+				match (process-version $version) {
+					true => { print $"  Added ($version)" }
+					false => {}
+				}
+			} | ignore
+		}
 	}
+
+	# Ensure the stable version is tracked before recording the channel marker.
+	# The marker must never point at a version file that does not exist, or the
+	# flake's `stable` alias would fail to evaluate — on failure keep the previous
+	# marker (still valid, stable naturally lags) and retry on the next run.
+	let stable_path = ($script_dir | path join "versions" $"($stable_version).json")
+	match ($stable_path | path exists) {
+		true => {}
+		false => {
+			print $"Processing stable ($stable_version)..."
+			process-version $stable_version | ignore
+		}
+	}
+	match ($stable_path | path exists) {
+		true => {
+			# The flake reads this marker to expose the `stable` package alias.
+			# The `latest` channel needs no marker: the flake derives it from
+			# the highest version file name.
+			$"($stable_version)\n" | save -f ($script_dir | path join "stable")
+			print $"Marked stable -> ($stable_version)"
+		}
+		false => {
+			print -e $"Keeping previous stable marker: failed to process stable ($stable_version)"
+		}
+	}
+
+	# Format with oxfmt
+	print "Formatting with oxfmt..."
+	cd $script_dir
+	oxfmt --config ($script_dir | path join ".oxfmtrc.jsonc") versions/*.json | ignore
+	print "Done!"
+
+	# Print the latest version as the final line for CI consumption
+	print $latest_version
 }
-
-# Ensure the stable version is tracked before recording the channel marker.
-# The marker must never point at a version file that does not exist, or the
-# flake's `stable` alias would fail to evaluate — on failure keep the previous
-# marker (still valid, stable naturally lags) and retry on the next run.
-let stable_path = ($script_dir | path join "versions" $"($stable_version).json")
-match ($stable_path | path exists) {
-	true => {}
-	false => {
-		print $"Processing stable ($stable_version)..."
-		process-version $stable_version | ignore
-	}
-}
-match ($stable_path | path exists) {
-	true => {
-		# The flake reads this marker to expose the `stable` package alias.
-		# The `latest` channel needs no marker: the flake derives it from
-		# the highest version file name.
-		$"($stable_version)\n" | save -f ($script_dir | path join "stable")
-		print $"Marked stable -> ($stable_version)"
-	}
-	false => {
-		print -e $"Keeping previous stable marker: failed to process stable ($stable_version)"
-	}
-}
-
-# Format with oxfmt
-print "Formatting with oxfmt..."
-cd $script_dir
-oxfmt --config ($script_dir | path join ".oxfmtrc.jsonc") versions/*.json | ignore
-print "Done!"
-
-# Print the latest version as the final line for CI consumption
-print $latest_version

--- a/update.nu
+++ b/update.nu
@@ -36,18 +36,22 @@ def semver-sort []: list<string> -> list<string> {
 # sorts the pair and tests whether `a` comes out on top. Both sides are
 # normalised through `into semver | into string` so a non-canonical input
 # string cannot break the equality test.
-def semver-gte [a: string, b: string] {
+def semver-gte [
+	a: string # the version being tested
+	b: string # the baseline it must reach
+]: nothing -> bool {
 	let last_sorted = ([$b $a] | each { into semver } | sort | last | into string)
 	$last_sorted == ($a | into semver | into string)
 }
 
 # Fetch a version string from a GCS distribution channel (`latest` or `stable`).
-def fetch-gcs-channel [channel: string] {
+def fetch-gcs-channel [channel: string]: nothing -> string {
 	http get $"($BASE_URL)/($channel)" | str trim
 }
 
-# Get all existing versions from the versions directory.
-def get-existing-versions [] {
+# Get all existing versions from the versions directory, ascending.
+# `latest` is null when no version file is tracked yet.
+def get-existing-versions []: nothing -> record<versions: list<string>, latest: any> {
 	let names = (
 		glob ($script_dir | path join "versions" "*.json")
 		| each { path parse | get stem }
@@ -62,7 +66,10 @@ def get-existing-versions [] {
 }
 
 # Write version sources to the versions directory.
-def write-version-sources [version: string, hashes: record] {
+def write-version-sources [
+	version: string
+	hashes: record # SRI hash per Nix platform, keyed as in `$platforms`
+]: nothing -> nothing {
 	let versioned_path = ($script_dir | path join "versions" $"($version).json")
 
 	let platforms_data = (
@@ -82,7 +89,7 @@ def write-version-sources [version: string, hashes: record] {
 
 # Fetch manifest, compute SRI hashes, and write the version file.
 # Returns true if the version was written, false if the manifest was unavailable.
-def process-version [version: string] {
+def process-version [version: string]: nothing -> bool {
 	let manifest = (try { http get $"($BASE_URL)/($version)/manifest.json" } catch {|err|
 		print -e $"  Skipping ($version): ($err.msg)"
 		null
@@ -120,7 +127,7 @@ def process-version [version: string] {
 # Backfill every version file missing from the tracked range, refresh the
 # `stable` channel marker, and print the newest known version as the final line
 # for CI consumption.
-def main [] {
+def main []: nothing -> nothing {
 	let existing = (get-existing-versions)
 	let existing_versions = $existing.versions
 	let current_version = $existing.latest


### PR DESCRIPTION
## Summary

Two `update.nu` cleanups against the Nushell style rules: wrap the top-level script body in `def main []`, and declare input/output types on every custom command.

## What changed

**`def main []`** — the script body was a sequence of top-level statements. Wrapping it makes the entry point explicit alongside the existing `def` helpers, scopes `cd $script_dir` to the function so it no longer leaks into the caller's environment, and turns the doc comment into real `--help` output.

**Typed signatures** — only `semver-sort` declared its types. Now all seven commands do. These are checked at parse time and surface in `--help`, so they document intent where a comment can drift:

- `semver-gte`, `process-version` → `bool`, making the true/false returns part of the contract
- `fetch-gcs-channel` → `string`
- `get-existing-versions` → `record<versions: list<string>, latest: any>`, where `any` records that `latest` is null until a version is tracked
- `write-version-sources`, `main` → `nothing`

Plus doc comments on the two parameters whose meaning isn't evident from the name: the argument order of `semver-gte`, and the keying of `hashes`.

## Behaviour is unchanged

For the first commit, `git diff -w` shows only the added `def main []` and its closing brace — the rest of that diff is re-indentation.

## Testing

- `nu --ide-check` reports no errors.
- Ran `./update.nu` end to end after each commit: exits 0, backfills correctly, skips the four npm versions with no GCS manifest, refreshes the `stable` marker, and still prints the version as the final line — which `.github/workflows/update.yaml` consumes via `tail -1`.
- `nu update.nu --help` renders the `main` doc comment and the `nothing -> nothing` signature.

## Not in this PR

`nufmt` has never been run on this file and isn't wired into `treefmt` (which has `nixfmt`, `deadnix`, `statix`, `typos`, `oxfmt`). `nufmt --dry-run` currently fails: it would convert the file's tabs to 4 spaces and re-break long pipelines, ~250 diff lines touching code unrelated to this change. Worth doing as its own PR, ideally together with adding `nufmt` to `treefmt` so it stays enforced.
