### PR TITLE
build(dev): check .nu files with nufmt, and format update.nu

### DIFF
--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -57,6 +57,14 @@
               typos.enable = true;
               oxfmt.enable = true;
             };
+
+            # treefmt-nix ships no nufmt module, so declare the formatter by
+            # hand. Without it `update.nu` is the one tracked source file that
+            # no formatter checks.
+            settings.formatter.nufmt = {
+              command = pkgs.lib.getExe pkgs.nufmt;
+              includes = [ "*.nu" ];
+            };
           };
 
           checks = {

--- a/update.nu
+++ b/update.nu
@@ -20,15 +20,15 @@ const NPM_LATEST_URL = $"($NPM_PACKAGE_URL)/latest"
 
 # Platform mappings (Nix platform -> manifest platform)
 const platforms = {
-	"x86_64-linux": "linux-x64"
-	"aarch64-linux": "linux-arm64"
-	"x86_64-darwin": "darwin-x64"
-	"aarch64-darwin": "darwin-arm64"
+    "x86_64-linux": "linux-x64"
+    "aarch64-linux": "linux-arm64"
+    "x86_64-darwin": "darwin-x64"
+    "aarch64-darwin": "darwin-arm64"
 }
 
 # Sort a list of version strings using semver ordering (ascending).
 def semver-sort []: list<string> -> list<string> {
-	$in | each { into semver } | sort | each { into string }
+    $in | each { into semver } | sort | each { into string }
 }
 
 # Check whether version `a` is greater than or equal to version `b`.
@@ -37,171 +37,188 @@ def semver-sort []: list<string> -> list<string> {
 # normalised through `into semver | into string` so a non-canonical input
 # string cannot break the equality test.
 def semver-gte [
-	a: string # the version being tested
-	b: string # the baseline it must reach
+    a: string # the version being tested
+    b: string # the baseline it must reach
 ]: nothing -> bool {
-	let last_sorted = ([$b $a] | each { into semver } | sort | last | into string)
-	$last_sorted == ($a | into semver | into string)
+    let last_sorted = (
+        [$b $a]
+        | each { into semver }
+        | sort
+        | last
+        | into string
+    )
+    $last_sorted == ($a | into semver | into string)
 }
 
 # Fetch a version string from a GCS distribution channel (`latest` or `stable`).
 def fetch-gcs-channel [channel: string]: nothing -> string {
-	http get $"($BASE_URL)/($channel)" | str trim
+    http get $"($BASE_URL)/($channel)" | str trim
 }
 
 # Get all existing versions from the versions directory, ascending.
 # `latest` is null when no version file is tracked yet.
 def get-existing-versions []: nothing -> record<versions: list<string>, latest: any> {
-	let names = (
-		glob ($script_dir | path join "versions" "*.json")
-		| each { path parse | get stem }
-	)
-	match ($names | is-empty) {
-		true => {versions: [], latest: null}
-		false => {
-			let sorted = ($names | semver-sort)
-			{versions: $sorted, latest: ($sorted | last)}
-		}
-	}
+    let names = (
+        glob ($script_dir | path join "versions" "*.json")
+        | each { path parse | get stem }
+    )
+    match ($names | is-empty) {
+        true => {
+            versions: []
+            latest: null
+        }
+        false => {
+            let sorted = $names | semver-sort
+            {
+                versions: $sorted
+                latest: ($sorted | last)
+            }
+        }
+    }
 }
 
 # Write version sources to the versions directory.
 def write-version-sources [
-	version: string
-	hashes: record # SRI hash per Nix platform, keyed as in `$platforms`
+    version: string
+    hashes: record # SRI hash per Nix platform, keyed as in `$platforms`
 ]: nothing -> nothing {
-	let versioned_path = ($script_dir | path join "versions" $"($version).json")
+    let versioned_path = $script_dir | path join "versions" $"($version).json"
 
-	let platforms_data = (
-		$platforms
-		| items {|nix_platform, manifest_platform|
-			{$nix_platform: {
-				url: $"($BASE_URL)/($version)/($manifest_platform)/claude"
-				hash: ($hashes | get $nix_platform)
-			}}
-		}
-		| reduce -f {} {|it, acc| $acc | merge $it}
-	)
+    let platforms_data = (
+        $platforms
+        | items {|nix_platform, manifest_platform|
+            {$nix_platform: {
+                url: $"($BASE_URL)/($version)/($manifest_platform)/claude"
+                hash: ($hashes | get $nix_platform)
+            }}
+        }
+        | reduce -f {} {|it, acc| $acc | merge $it}
+    )
 
-	let sources_data = {version: $version, platforms: $platforms_data}
-	(($sources_data | to json --indent 2) + "\n") | save -f $versioned_path
+    let sources_data = {version: $version, platforms: $platforms_data}
+    (($sources_data | to json --indent 2) + "\n") | save -f $versioned_path
 }
 
 # Fetch manifest, compute SRI hashes, and write the version file.
 # Returns true if the version was written, false if the manifest was unavailable.
 def process-version [version: string]: nothing -> bool {
-	let manifest = (try { http get $"($BASE_URL)/($version)/manifest.json" } catch {|err|
-		print -e $"  Skipping ($version): ($err.msg)"
-		null
-	})
+    let manifest = (try { http get $"($BASE_URL)/($version)/manifest.json" } catch {|err|
+        print -e $"  Skipping ($version): ($err.msg)"
+        null
+    })
 
-	match $manifest {
-		null => false
-		_ => {
-			let results = (
-				$platforms
-				| items {|nix_platform, manifest_platform|
-					let platform_data = ($manifest.platforms | get -o $manifest_platform)
-					match $platform_data {
-						null => {
-							print -e $"  Skipping ($version): missing platform ($manifest_platform)"
-							null
-						}
-						_ => {$nix_platform: (nix hash to-sri --type sha256 $platform_data.checksum | str trim)}
-					}
-				}
-			)
+    match $manifest {
+        null => false
+        _ => {
+            let results = (
+                $platforms
+                | items {|nix_platform, manifest_platform|
+                    let platform_data = $manifest.platforms | get -o $manifest_platform
+                    match $platform_data {
+                        null => {
+                            print -e $"  Skipping ($version): missing platform ($manifest_platform)"
+                            null
+                        }
+                        _ => {$nix_platform: (nix hash to-sri --type sha256 $platform_data.checksum | str trim)}
+                    }
+                }
+            )
 
-			match ($results | any {|r| $r == null}) {
-				true => false
-				false => {
-					let hashes = ($results | reduce -f {} {|it, acc| $acc | merge $it})
-					write-version-sources $version $hashes
-					true
-				}
-			}
-		}
-	}
+            match ($results | any {|r| $r == null}) {
+                true => false
+                false => {
+                    let hashes = $results | reduce -f {} {|it, acc| $acc | merge $it}
+                    write-version-sources $version $hashes
+                    true
+                }
+            }
+        }
+    }
 }
 
 # Backfill every version file missing from the tracked range, refresh the
 # `stable` channel marker, and print the newest known version as the final line
 # for CI consumption.
 def main []: nothing -> nothing {
-	let existing = (get-existing-versions)
-	let existing_versions = $existing.versions
-	let current_version = $existing.latest
+    let existing = (get-existing-versions)
+    let existing_versions = $existing.versions
+    let current_version = $existing.latest
 
-	let all_npm_versions = (http get $NPM_PACKAGE_URL | get versions | columns | semver-sort)
-	let npm_latest = (http get $NPM_LATEST_URL | get version)
-	# The stable channel intentionally lags behind the latest release.
-	let gcs_latest = (fetch-gcs-channel "latest")
-	let stable_version = (fetch-gcs-channel "stable")
+    let all_npm_versions = (
+        http get $NPM_PACKAGE_URL
+        | get versions
+        | columns
+        | semver-sort
+    )
+    let npm_latest = http get $NPM_LATEST_URL | get version
+    # The stable channel intentionally lags behind the latest release.
+    let gcs_latest = (fetch-gcs-channel "latest")
+    let stable_version = (fetch-gcs-channel "stable")
 
-	# Determine the newest version reported by either source.
-	let latest_version = ([$npm_latest $gcs_latest] | semver-sort | last)
+    # Determine the newest version reported by either source.
+    let latest_version = [$npm_latest $gcs_latest] | semver-sort | last
 
-	print $"Current version: ($current_version)"
-	print $"npm latest:      ($npm_latest)"
-	print $"GCS latest:      ($gcs_latest)"
-	print $"GCS stable:      ($stable_version)"
-	print $"Latest version:  ($latest_version)"
+    print $"Current version: ($current_version)"
+    print $"npm latest:      ($npm_latest)"
+    print $"GCS latest:      ($gcs_latest)"
+    print $"GCS stable:      ($stable_version)"
+    print $"Latest version:  ($latest_version)"
 
-	# Find the earliest existing version to determine the backfill range.
-	# Only backfill versions >= the earliest version we already track.
-	let earliest = ($existing_versions | get 0?)
+    # Find the earliest existing version to determine the backfill range.
+    # Only backfill versions >= the earliest version we already track.
+    let earliest = $existing_versions | get 0?
 
-	let missing_versions = (
-		$all_npm_versions
-		| where {|v| $v not-in $existing_versions and ($earliest == null or (semver-gte $v $earliest))}
-	)
+    let missing_versions = (
+        $all_npm_versions
+        | where {|v| $v not-in $existing_versions and ($earliest == null or (semver-gte $v $earliest))}
+    )
 
-	match ($missing_versions | is-empty) {
-		true => { print "All versions are up to date!" }
-		false => {
-			print $"Found ($missing_versions | length) missing version\(s\): ($missing_versions | str join ', ')"
+    match ($missing_versions | is-empty) {
+        true => { print "All versions are up to date!" }
+        false => {
+            print $"Found ($missing_versions | length) missing version\(s\): ($missing_versions | str join ', ')"
 
-			$missing_versions | each {|version|
-				print $"Processing ($version)..."
-				match (process-version $version) {
-					true => { print $"  Added ($version)" }
-					false => {}
-				}
-			} | ignore
-		}
-	}
+            $missing_versions | each {|version|
+                print $"Processing ($version)..."
+                match (process-version $version) {
+                    true => { print $"  Added ($version)" }
+                    false => {}
+                }
+            } | ignore
+        }
+    }
 
-	# Ensure the stable version is tracked before recording the channel marker.
-	# The marker must never point at a version file that does not exist, or the
-	# flake's `stable` alias would fail to evaluate — on failure keep the previous
-	# marker (still valid, stable naturally lags) and retry on the next run.
-	let stable_path = ($script_dir | path join "versions" $"($stable_version).json")
-	match ($stable_path | path exists) {
-		true => {}
-		false => {
-			print $"Processing stable ($stable_version)..."
-			process-version $stable_version | ignore
-		}
-	}
-	match ($stable_path | path exists) {
-		true => {
-			# The flake reads this marker to expose the `stable` package alias.
-			# The `latest` channel needs no marker: the flake derives it from
-			# the highest version file name.
-			$"($stable_version)\n" | save -f ($script_dir | path join "stable")
-			print $"Marked stable -> ($stable_version)"
-		}
-		false => {
-			print -e $"Keeping previous stable marker: failed to process stable ($stable_version)"
-		}
-	}
+    # Ensure the stable version is tracked before recording the channel marker.
+    # The marker must never point at a version file that does not exist, or the
+    # flake's `stable` alias would fail to evaluate — on failure keep the previous
+    # marker (still valid, stable naturally lags) and retry on the next run.
+    let stable_path = $script_dir | path join "versions" $"($stable_version).json"
+    match ($stable_path | path exists) {
+        true => { }
+        false => {
+            print $"Processing stable ($stable_version)..."
+            process-version $stable_version | ignore
+        }
+    }
+    match ($stable_path | path exists) {
+        true => {
+            # The flake reads this marker to expose the `stable` package alias.
+            # The `latest` channel needs no marker: the flake derives it from
+            # the highest version file name.
+            $"($stable_version)\n" | save -f ($script_dir | path join "stable")
+            print $"Marked stable -> ($stable_version)"
+        }
+        false => {
+            print -e $"Keeping previous stable marker: failed to process stable ($stable_version)"
+        }
+    }
 
-	# Format with oxfmt
-	print "Formatting with oxfmt..."
-	cd $script_dir
-	oxfmt --config ($script_dir | path join ".oxfmtrc.jsonc") versions/*.json | ignore
-	print "Done!"
+    # Format with oxfmt
+    print "Formatting with oxfmt..."
+    cd $script_dir
+    oxfmt --config ($script_dir | path join ".oxfmtrc.jsonc") versions/*.json | ignore
+    print "Done!"
 
-	# Print the latest version as the final line for CI consumption
-	print $latest_version
+    # Print the latest version as the final line for CI consumption
+    print $latest_version
 }


### PR DESCRIPTION
## Summary

`treefmt` ran `nixfmt`, `deadnix`, `statix`, `typos` and `oxfmt`, which left `update.nu` as the only tracked source file that no formatter checked. This wires `nufmt` into `treefmt` and applies it.

## What changed

**`dev/flake.nix`** — `treefmt-nix` ships no `nufmt` module, so the formatter is declared by hand via `settings.formatter`. `nix flake check` and the pre-commit hook now fail on unformatted Nushell, the same as for every other language here.

**`update.nu`** — pure formatting. `nufmt` breaks long pipelines and inline records across lines, drops redundant parentheses around a piped `let`, and indents with four spaces.

## One manual step worth reviewing

Leading tabs are expanded by hand rather than by `nufmt`. `nufmt` reformats statement bodies but leaves continuation lines inside parameter lists and parenthesised pipelines untouched, so running it alone produced a file mixing 4-space indentation at statement level with tabs inside `def` parameter lists — and it reported that state as "already formatted". Expanding the leading tabs first makes `nufmt` idempotent (`--dry-run` exits 0).

Only leading whitespace was touched; the file had no mid-line tabs.

## Testing

- `nix build .#checks.<system>.treefmt` fails before the formatting commit and passes after, confirming the formatter is actually enforced rather than just configured.
- `nufmt --dry-run` exits 0, and re-running `nufmt` reports no further changes.
- `nu --ide-check` reports no errors.
- Checked one risky rewrite explicitly: `nufmt` expands `true => {versions: [], latest: null}` in `get-existing-versions` into a multi-line `{ ... }`, which could have been reparsed as a block instead of a record. Confirmed with `describe` that it is still `record<versions: ..., latest: ...>`.
- Full `./update.nu` run: exits 0, backfills correctly, refreshes the `stable` marker, still prints the version as the final line for `tail -1`, and `--help` still renders.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `nufmt` to `treefmt` to enforce formatting for Nushell files and formats `update.nu`. Unformatted `.nu` now fails `nix flake check` and the pre-commit hook.

- **Refactors**
  - Added `nufmt` to `treefmt` via custom `settings.formatter` (no built-in `treefmt-nix` module).
  - Reformatted `update.nu` with `nufmt`; expanded leading tabs to spaces for consistent indentation. No behavior change.

<sup>Written for commit d28b94b02bf407fa416d308f66a36b0f81b17a1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/nix-claude-code/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

