### PR TITLE
refactor(nix): replace stdenv.isLinux with stdenv.hostPlatform.isLinux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
           latestSourcesFile = ./versions/${latestVersion + ".json"};
           stableSourcesFile = ./versions/${stableVersion + ".json"};
 
-          fhsPackages = nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          fhsPackages = nixpkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
             claude-fhs = mkClaudeFhs (mkClaude latestSourcesFile);
             claude-minimal-fhs = mkClaudeFhs (mkClaudeMinimal latestSourcesFile);
             stable-fhs = mkClaudeFhs (mkClaude stableSourcesFile);
@@ -87,7 +87,7 @@
           claude-code = self.packages.${prev.stdenv.hostPlatform.system}.claude;
           claude-code-minimal = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal;
         }
-        // nixpkgs.lib.optionalAttrs prev.stdenv.isLinux {
+        // nixpkgs.lib.optionalAttrs prev.stdenv.hostPlatform.isLinux {
           claude-code-fhs = self.packages.${prev.stdenv.hostPlatform.system}.claude-fhs;
           claude-code-minimal-fhs = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal-fhs;
         };

--- a/package.nix
+++ b/package.nix
@@ -30,9 +30,12 @@ stdenv.mkDerivation rec {
     inherit (source) url hash;
   };
 
-  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-  buildInputs = lib.optionals stdenv.isLinux [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     stdenv.cc.cc.lib
     zlib
   ];


### PR DESCRIPTION
Evaluating this flake against current nixpkgs prints a warning for every access to `stdenv.isLinux`:

```
evaluation warning: stdenv.isLinux is deprecated, use stdenv.hostPlatform.isLinux instead
```

The alias was deprecated in NixOS/nixpkgs#518407.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace deprecated `stdenv.isLinux` with `stdenv.hostPlatform.isLinux` to remove evaluation warnings on current `nixpkgs`. Behavior is unchanged; Linux-only logic and outputs remain the same.

- Update guards in `flake.nix` and `package.nix` to use `stdenv.hostPlatform.isLinux` for FHS packages and Linux-only inputs.
- No migration required; expect the same packages on Linux and none on non-Linux.
- Review by evaluating the flake against current `nixpkgs` to confirm no deprecation warnings and building on Linux and macOS.

<sup>Written for commit 12d65c0ff5c3372f370b2a874331d100be2ab752. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/nix-claude-code/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux platform detection during package evaluation and builds.
  * Ensured Linux-specific build inputs are applied more reliably based on the target platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->