### PR TITLE
fix: replace deprecated stdenv.isLinux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
           latestSourcesFile = ./versions/${latestVersion + ".json"};
           stableSourcesFile = ./versions/${stableVersion + ".json"};
 
-          fhsPackages = nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          fhsPackages = nixpkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
             claude-fhs = mkClaudeFhs (mkClaude latestSourcesFile);
             claude-minimal-fhs = mkClaudeFhs (mkClaudeMinimal latestSourcesFile);
             stable-fhs = mkClaudeFhs (mkClaude stableSourcesFile);
@@ -87,7 +87,7 @@
           claude-code = self.packages.${prev.stdenv.hostPlatform.system}.claude;
           claude-code-minimal = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal;
         }
-        // nixpkgs.lib.optionalAttrs prev.stdenv.isLinux {
+        // nixpkgs.lib.optionalAttrs prev.stdenv.hostPlatform.isLinux {
           claude-code-fhs = self.packages.${prev.stdenv.hostPlatform.system}.claude-fhs;
           claude-code-minimal-fhs = self.packages.${prev.stdenv.hostPlatform.system}.claude-minimal-fhs;
         };

--- a/package.nix
+++ b/package.nix
@@ -30,9 +30,9 @@ stdenv.mkDerivation rec {
     inherit (source) url hash;
   };
 
-  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-  buildInputs = lib.optionals stdenv.isLinux [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     stdenv.cc.cc.lib
     zlib
   ];


### PR DESCRIPTION
every evaluation of this flake emits `evaluation warning: stdenv.isLinux is deprecated, use stdenv.hostPlatform.isLinux instead`, which surfaces on any `nixos-rebuild` that pulls the overlay in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace deprecated `stdenv.isLinux` with `stdenv.hostPlatform.isLinux` to remove flake evaluation warnings during `nix build` and `nixos-rebuild`. Previously every eval emitted a deprecation warning; now evals are quiet with no change to platform gating.

- Updates `flake.nix` (`fhsPackages` and output gating) and `package.nix` (`nativeBuildInputs` and `buildInputs`) to use `hostPlatform.isLinux`.
- Linux-only pieces (`autoPatchelfHook`, `stdenv.cc.cc.lib`, `zlib`, FHS packages) remain gated by the host platform. No migration required.

<sup>Written for commit 06265d6eb5da71368ab5747c23fccc1ee5c56bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/nix-claude-code/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux platform detection for packaging and runtime dependency handling.
  * Updated platform checks to ensure more reliable behavior on current Nix environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->